### PR TITLE
remove react as dependency and add as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "classnames": "^2.2.5",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.8",
-    "react": "^15.5.4",
     "react-simple-dropdown": "^3.2.0"
   },
   "devDependencies": {
@@ -52,6 +51,7 @@
     "jsdom": "^11.2.0",
     "jsdom-global": "^3.0.2",
     "nyc": "^11.2.1",
+    "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "react-test-renderer": "^16.0.0",
     "rimraf": "^2.6.1",


### PR DESCRIPTION
Should help prevent apps consuming this component from loading multiple version of React.

#19 