### PR TITLE
Improvement: remove usage of !important to remove the padding of nodes during  search

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,13 @@ Type: `string`
 
 The text to display as placeholder on the search box. Defaults to `Choose...`
 
+### keepTreeOnSearch
+
+
+Type: `bool`
+
+Displays search results as a tree instead of flatten results
+
 ## Styling and Customization
 
 ### Default styles

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
 /* component styles */
-.hide {
+.hide:not(.match-in-children) {
   display: none;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -163,10 +163,10 @@ class DropdownTreeSelect extends Component {
               ) : (
                 <Tree
                   data={this.state.tree}
-                  searchModeOn={this.state.searchModeOn}
                   onAction={this.onAction}
                   onCheckboxChange={this.onCheckboxChange}
                   onNodeToggle={this.onNodeToggle}
+                  searchModeOn={this.state.searchModeOn}
                 />
               )}
             </div>

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ const cx = cn.bind(styles)
 class DropdownTreeSelect extends Component {
   static propTypes = {
     data: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
+    keepTreeOnSearch: PropTypes.bool,
     placeholderText: PropTypes.string,
     showDropdown: PropTypes.bool,
     className: PropTypes.string,
@@ -163,10 +164,11 @@ class DropdownTreeSelect extends Component {
               ) : (
                 <Tree
                   data={this.state.tree}
+                  keepTreeOnSearch={this.props.keepTreeOnSearch}
+                  searchModeOn={this.state.searchModeOn}
                   onAction={this.onAction}
                   onCheckboxChange={this.onCheckboxChange}
                   onNodeToggle={this.onNodeToggle}
-                  searchModeOn={this.state.searchModeOn}
                 />
               )}
             </div>

--- a/src/tree-manager/index.js
+++ b/src/tree-manager/index.js
@@ -49,16 +49,30 @@ class TreeManager {
     return matches
   }
 
+  setChildMatchStatus(id) {
+    const node = this.getNodeById(id)
+    node.matchInChildren = true
+
+    if (node._parent !== undefined) {
+      this.setChildMatchStatus(node._parent)
+    }
+  }
+
   filterTree (searchTerm) {
     const matches = this.getMatches(searchTerm.toLowerCase())
 
     this.tree.forEach(node => {
       node.hide = true
+      node.matchInChildren = false
     })
 
     matches.forEach(m => {
       const node = this.getNodeById(m)
       node.hide = false
+
+      if (node._parent !== undefined) {
+        this.setChildMatchStatus(node._parent)
+      }
     })
 
     const allNodesHidden = matches.length === 0

--- a/src/tree-manager/index.js
+++ b/src/tree-manager/index.js
@@ -49,11 +49,10 @@ class TreeManager {
     return matches
   }
 
-  setChildMatchStatus(id) {
-    const node = this.getNodeById(id)
-    node.matchInChildren = true
-
-    if (node._parent !== undefined) {
+  setChildMatchStatus (id) {
+    if (id !== undefined) {
+      const node = this.getNodeById(id)
+      node.matchInChildren = true
       this.setChildMatchStatus(node._parent)
     }
   }
@@ -69,10 +68,7 @@ class TreeManager {
     matches.forEach(m => {
       const node = this.getNodeById(m)
       node.hide = false
-
-      if (node._parent !== undefined) {
-        this.setChildMatchStatus(node._parent)
-      }
+      this.setChildMatchStatus(node._parent)
     })
 
     const allNodesHidden = matches.length === 0

--- a/src/tree-node/index.css
+++ b/src/tree-node/index.css
@@ -4,10 +4,6 @@
   padding: 4px;
 }
 
-.searchModeOn li.node {
-  padding-left: 0 !important;
-}
-
 .toggle {
   white-space: pre;
   margin-right: 4px;

--- a/src/tree-node/index.css
+++ b/src/tree-node/index.css
@@ -37,5 +37,5 @@
 }
 
 .match-in-children.hide .node-label {
-  opacity: .5;
+  opacity: 0.5;
 }

--- a/src/tree-node/index.css
+++ b/src/tree-node/index.css
@@ -35,3 +35,7 @@
   vertical-align: middle;
   margin: 0 4px 0 0;
 }
+
+.match-in-children.hide .node-label {
+  opacity: .5;
+}

--- a/src/tree-node/index.js
+++ b/src/tree-node/index.js
@@ -8,15 +8,19 @@ import styles from './index.css'
 const cx = cn.bind(styles)
 
 const TreeNode = props => {
-  const { node, onNodeToggle, onCheckboxChange, onAction, searchModeOn } = props
+  const { keepTreeOnSearch, node, searchModeOn, onNodeToggle, onCheckboxChange, onAction } = props
   const actions = node.actions || []
   const isLeaf = isEmpty(node._children)
-  const liCx = cx('node', { leaf: isLeaf, tree: !isLeaf, hide: node.hide }, node.className)
+  const liCx = cx(
+    'node',
+    { leaf: isLeaf, tree: !isLeaf, hide: node.hide, 'match-in-children': keepTreeOnSearch && node.matchInChildren },
+    node.className
+  )
   const toggleCx = cx('toggle', { expanded: !isLeaf && node.expanded, collapsed: !isLeaf && !node.expanded })
 
   return (
-    <li className={liCx} style={!searchModeOn ? { paddingLeft: `${node._depth * 20}px` } : {}}>
-      <i className={toggleCx} onClick={() => onNodeToggle(node._id)} />
+    <li className={liCx} style={keepTreeOnSearch || !searchModeOn ? { paddingLeft: `${node._depth * 20}px` } : {}}>
+      {(!searchModeOn || keepTreeOnSearch) && <i className={toggleCx} onClick={() => onNodeToggle(node._id)} />}
       <label title={node.title || node.label}>
         <input
           type="checkbox"
@@ -47,10 +51,11 @@ TreeNode.propTypes = {
     checked: PropTypes.bool,
     expanded: PropTypes.bool
   }).isRequired,
+  keepTreeOnSearch: PropTypes.bool,
+  searchModeOn: PropTypes.bool,
   onNodeToggle: PropTypes.func,
   onAction: PropTypes.func,
-  onCheckboxChange: PropTypes.func,
-  searchModeOn: PropTypes.bool
+  onCheckboxChange: PropTypes.func
 }
 
 export default TreeNode

--- a/src/tree-node/index.js
+++ b/src/tree-node/index.js
@@ -8,14 +8,14 @@ import styles from './index.css'
 const cx = cn.bind(styles)
 
 const TreeNode = props => {
-  const { node, onNodeToggle, onCheckboxChange, onAction } = props
+  const { node, onNodeToggle, onCheckboxChange, onAction, searchModeOn } = props
   const actions = node.actions || []
   const isLeaf = isEmpty(node._children)
   const liCx = cx('node', { leaf: isLeaf, tree: !isLeaf, hide: node.hide }, node.className)
   const toggleCx = cx('toggle', { expanded: !isLeaf && node.expanded, collapsed: !isLeaf && !node.expanded })
 
   return (
-    <li className={liCx} style={{ paddingLeft: `${node._depth * 20}px` }}>
+    <li className={liCx} style={!searchModeOn ? { paddingLeft: `${node._depth * 20}px` } : {}}>
       <i className={toggleCx} onClick={() => onNodeToggle(node._id)} />
       <label title={node.title || node.label}>
         <input
@@ -49,7 +49,8 @@ TreeNode.propTypes = {
   }).isRequired,
   onNodeToggle: PropTypes.func,
   onAction: PropTypes.func,
-  onCheckboxChange: PropTypes.func
+  onCheckboxChange: PropTypes.func,
+  searchModeOn: PropTypes.bool
 }
 
 export default TreeNode

--- a/src/tree-node/index.js
+++ b/src/tree-node/index.js
@@ -9,18 +9,15 @@ const cx = cn.bind(styles)
 
 const TreeNode = props => {
   const { keepTreeOnSearch, node, searchModeOn, onNodeToggle, onCheckboxChange, onAction } = props
-  const actions = node.actions || []
   const isLeaf = isEmpty(node._children)
-  const liCx = cx(
-    'node',
-    { leaf: isLeaf, tree: !isLeaf, hide: node.hide, 'match-in-children': keepTreeOnSearch && node.matchInChildren },
-    node.className
-  )
+  const hasMatchInChildren = keepTreeOnSearch && node.matchInChildren
+  const nodeCx = { leaf: isLeaf, tree: !isLeaf, hide: node.hide, 'match-in-children': hasMatchInChildren }
+  const liCx = cx('node', nodeCx, node.className)
   const toggleCx = cx('toggle', { expanded: !isLeaf && node.expanded, collapsed: !isLeaf && !node.expanded })
 
   return (
     <li className={liCx} style={keepTreeOnSearch || !searchModeOn ? { paddingLeft: `${node._depth * 20}px` } : {}}>
-      {(!searchModeOn || keepTreeOnSearch) && <i className={toggleCx} onClick={() => onNodeToggle(node._id)} />}
+      <i className={toggleCx} onClick={() => onNodeToggle(node._id)} />
       <label title={node.title || node.label}>
         <input
           type="checkbox"
@@ -32,7 +29,7 @@ const TreeNode = props => {
         />
         <span className="node-label">{node.label}</span>
       </label>
-      {actions.map((a, idx) => (
+      {(node.actions || []).map((a, idx) => (
         <Action key={`action-${idx}`} {...a} actionData={{ action: a.id, node }} onAction={onAction} />
       ))}
     </li>

--- a/src/tree-node/index.test.js
+++ b/src/tree-node/index.test.js
@@ -4,6 +4,10 @@ import { shallow } from 'enzyme'
 import { spy } from 'sinon'
 import TreeNode from './index'
 
+const hasGap = (wrapper) => {
+  return !!wrapper.find('li').first().props().style.paddingLeft
+}
+
 test('renders tree node', t => {
   const node = {
     _id: '0-0-0',
@@ -26,6 +30,7 @@ test('renders tree node', t => {
   t.true(wrapper.find('.toggle').exists())
   t.true(wrapper.find('label').exists())
   t.true(wrapper.find('.checkbox-item').exists())
+  t.true(hasGap(wrapper))
 })
 
 test('notifies checkbox changes', t => {
@@ -59,4 +64,18 @@ test('notifies node toggle changes', t => {
   const wrapper = shallow(<TreeNode node={node} onNodeToggle={onChange} />)
   wrapper.find('.toggle').simulate('click')
   t.true(onChange.calledWith('0-0-0'))
+})
+
+test('remove gap during search', t => {
+  const node = {
+    _id: '0-0-0',
+    _parent: '0-0',
+    label: 'item1-1-1',
+    value: 'value1-1-1',
+    className: 'cn0-0-0'
+  }
+
+  const wrapper = shallow(<TreeNode node={node} searchModeOn={true} />)
+
+  t.false(hasGap(wrapper))
 })

--- a/src/tree/index.js
+++ b/src/tree/index.js
@@ -12,19 +12,20 @@ const shouldRenderNode = (node, searchModeOn, data) => {
 }
 
 const getNodes = props => {
-  const { searchModeOn, data, onAction, onChange, onCheckboxChange, onNodeToggle } = props
+  const { data, keepTreeOnSearch, searchModeOn, onAction, onChange, onCheckboxChange, onNodeToggle } = props
   const items = []
   data.forEach((node, key) => {
     if (shouldRenderNode(node, searchModeOn, data)) {
       items.push(
         <TreeNode
+          keepTreeOnSearch={keepTreeOnSearch}
           key={key}
           node={node}
+          searchModeOn={searchModeOn}
           onChange={onChange}
           onCheckboxChange={onCheckboxChange}
           onNodeToggle={onNodeToggle}
           onAction={onAction}
-          searchModeOn={searchModeOn}
         />
       )
     }
@@ -40,6 +41,7 @@ const Tree = props => {
 
 Tree.propTypes = {
   data: PropTypes.object,
+  keepTreeOnSearch: PropTypes.bool,
   searchModeOn: PropTypes.bool,
   onChange: PropTypes.func,
   onNodeToggle: PropTypes.func,

--- a/src/tree/index.js
+++ b/src/tree/index.js
@@ -24,6 +24,7 @@ const getNodes = props => {
           onCheckboxChange={onCheckboxChange}
           onNodeToggle={onNodeToggle}
           onAction={onAction}
+          searchModeOn={searchModeOn}
         />
       )
     }


### PR DESCRIPTION
feat: remove cascading `!important` in css for hidden nodes (it's repaced by JS conditional style  and allow to  override this behaviour easily)
feat: add a "keepTreeOnSearch" prop to display results as a tree instead of flattening them (parent that don't match but with children which match are displayed with a specific class (ATM, it reduces opacity too))