### PR TITLE
feat: embed children and leaves count on node and tag component to allow a better customisation via CSS

### DIFF
--- a/src/input/index.js
+++ b/src/input/index.js
@@ -9,10 +9,15 @@ const cx = cn.bind(styles)
 
 const getTags = (tags = [], onDelete) => {
   return tags.map((tag, i) => {
-    const {_id, label, tagClassName} = tag
+    const {_id, _children, _nbLeaves, label, tagClassName} = tag
     return (
       <li className={cx('tag-item', tagClassName)} key={`tag-${i}`}>
-        <Tag label={label} id={_id} onDelete={onDelete}/>
+        <Tag
+          label={label}
+          id={_id}
+          nbChildren={_children ? _children.length : 0}
+          nbLeaves={_nbLeaves}
+          onDelete={onDelete}/>
       </li>
     )
   })

--- a/src/tag/index.js
+++ b/src/tag/index.js
@@ -16,7 +16,7 @@ const Tag = (props) => {
   }
 
   return (
-    <span className={cx('tag')}>
+    <span className={cx('tag')} data-nb-children={props.nbChildren} data-nb-leaves={props.nbLeaves}>
       {label}
       <button onClick={onClick} className={cx('tag-remove')} type='button'>x</button>
     </span>
@@ -26,6 +26,8 @@ const Tag = (props) => {
 Tag.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
+  nbChildren: PropTypes.number,
+  nbLeaves: PropTypes.number,
   onDelete: PropTypes.func
 }
 

--- a/src/tree-manager/flatten-tree.js
+++ b/src/tree-manager/flatten-tree.js
@@ -131,11 +131,27 @@ function walkNodes ({nodes, list = new Map(), parent, depth = 0}) {
     list.set(node._id, node)
     if (node.children) {
       node._children = []
+      node._nbLeaves = getLeafCount(node)
       walkNodes({nodes: node.children, list, parent: node, depth: depth + 1})
       node.children = undefined
     }
   })
   return list
+}
+
+/**
+ * Recursively count the number of leaves for a specific node
+ *
+ * @param node
+ * @returns {number}
+ */
+function getLeafCount (node) {
+  if (!node.children) {
+    return 1
+  }
+
+  return node.children.map(getLeafCount)
+    .reduce((last, current) => last + current, 0)
 }
 
 export default flattenTree

--- a/src/tree-manager/flatten-tree.test.js
+++ b/src/tree-manager/flatten-tree.test.js
@@ -42,6 +42,7 @@ test('flattens tree with no root', t => {
         '0-1'
       ],
       _depth: 0,
+      _nbLeaves: 3,
       children: undefined,
       name: 'item1',
       value: 'value1'
@@ -53,6 +54,7 @@ test('flattens tree with no root', t => {
         '1-1'
       ],
       _depth: 0,
+      _nbLeaves: 4,
       children: undefined,
       name: 'item2',
       value: 'value2'
@@ -65,6 +67,7 @@ test('flattens tree with no root', t => {
         '0-0-1'
       ],
       _depth: 1,
+      _nbLeaves: 2,
       children: undefined,
       name: 'item1-1',
       value: 'value1-1'
@@ -99,6 +102,7 @@ test('flattens tree with no root', t => {
         '1-0-2'
       ],
       _depth: 1,
+      _nbLeaves: 3,
       children: undefined,
       name: 'item2-1',
       value: 'value2-1'
@@ -131,6 +135,7 @@ test('flattens tree with no root', t => {
         '1-0-2-0'
       ],
       _depth: 2,
+      _nbLeaves: 1,
       children: undefined,
       name: 'item2-1-3',
       value: 'value2-1-3'
@@ -170,6 +175,7 @@ test('flattens tree with root', t => {
         '0-1'
       ],
       _depth: 0,
+      _nbLeaves: 3,
       children: undefined,
       name: 'item1',
       value: 'value1'
@@ -182,6 +188,7 @@ test('flattens tree with root', t => {
         '0-0-1'
       ],
       _depth: 1,
+      _nbLeaves: 2,
       children: undefined,
       name: 'item1-1',
       value: 'value1-1'

--- a/src/tree-node/index.js
+++ b/src/tree-node/index.js
@@ -45,7 +45,11 @@ const TreeNode = props => {
   const liCx = getNodeCx(props)
   const toggleCx = getToggleCx(props)
   return (
-    <li className={liCx} style={keepTreeOnSearch || !searchModeOn ? { paddingLeft: `${node._depth * 20}px` } : {}}>
+    <li
+      data-nb-children={node._children ? node._children.length : 0}
+      data-nb-leaves={node._nbLeaves}
+      className={liCx}
+      style={keepTreeOnSearch || !searchModeOn ? { paddingLeft: `${node._depth * 20}px` } : {}}>
       <i className={toggleCx} onClick={() => onNodeToggle(node._id)} />
       <label title={node.title || node.label}>
         <input


### PR DESCRIPTION
Allow customization like this with small piece of CSS:
![capture d ecran de 2018-03-05 16-56-40](https://user-images.githubusercontent.com/1257968/36985278-17ade716-2097-11e8-9a7d-1f9a4713e806.png)

@mrchief Keep me informed if you want me to change implementation.
