### PR TITLE
fix: Unregister event listener for simpleSelect :bug:

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -133,6 +133,10 @@ class DropdownTreeSelect extends Component {
       Object.assign(nextState, this.resetSearchState())
     }
 
+    if (this.props.simpleSelect) {
+      document.removeEventListener('click', this.handleOutsideClick, false)
+    }
+
     this.setState(nextState)
     this.notifyChange(this.treeManager.getNodeById(id), tags)
   }


### PR DESCRIPTION
When using simpleSelect, and having multiple instances of the component on the same page, opening
dropdown content after selecting something in another dropdwon causes the previous dropdown to open
as well. This happens since  `handleOutsideClick` is still listening for changes on the previous
instance.