### PR TITLE
Update webpack config to use babel presets and plugins

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,17 @@ module.exports = {
     rules: [
       {
         test: /\.js$/,
-        loaders: ['babel-loader'],
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['es2015', 'react', 'stage-0'],
+            plugins: [
+              'istanbul',
+              'transform-class-properties',
+              'transform-react-remove-prop-types'
+            ]
+          }
+        },
         include: path.join(__dirname, 'src'),
         exclude: /node_modules/
       },


### PR DESCRIPTION
Main reason for this change is to transpile ES6 code. I noticed you guys had babel presets/plugins defined in the `package.json` so I was hoping they were intended to be used.

Note that this does make the final file generated bigger (40K to 112K). This can be reduced to 48K if you don't need the following babel plugins applied:
* istanbul
* transform-class-properties
* transform-react-remove-prop-types

This change would help fix an issue with a project we're working on. Our current test infrastructure doesn't like ES6 code sadly :(

Thanks!