### PR TITLE
fix: Firefox outsideClick verification fails on certain elements (#148)

### DIFF
--- a/src/utils/isOutsideClick.js
+++ b/src/utils/isOutsideClick.js
@@ -1,5 +1,5 @@
 const getPath = e => {
-  let easyPath = e.path || (e.composedPath && e.composedPath());
+  const easyPath = e.path || (e.composedPath && e.composedPath())
   if (easyPath) return easyPath
 
   let elem = e.target

--- a/src/utils/isOutsideClick.js
+++ b/src/utils/isOutsideClick.js
@@ -1,5 +1,6 @@
 const getPath = e => {
-  if (e.path) return e.path
+  let easyPath = e.path || (e.composedPath && e.composedPath());
+  if (easyPath) return easyPath
 
   let elem = e.target
   const path = [elem]


### PR DESCRIPTION
#148 partial fix. Now the tree display remains open, however scroll position is incorrectly reset