### PR TITLE
fix: Typing error for children

### DIFF
--- a/types/react-dropdown-tree-select.d.ts
+++ b/types/react-dropdown-tree-select.d.ts
@@ -119,7 +119,7 @@ declare module "react-dropdown-tree-select" {
 
     export interface TreeNodeProps extends TreeNode {
         /** Array of child objects */
-        children?: Node[];
+        children?: TreeNode[];
     }
 
     export interface NodeAction {


### PR DESCRIPTION
## What does it do?

An issue in #223 for children. An array of Node[] instead of TreeNode[] was specified.

## Type of change

- [x] Bug fix
