### PR TITLE
fix: Only adjust scroll on active descendant change

### DIFF
--- a/src/tree/index.js
+++ b/src/tree/index.js
@@ -49,6 +49,7 @@ class Tree extends Component {
     this.computeInstanceProps(nextProps)
     this.setState({ items: this.allVisibleNodes.slice(0, this.currentPage * this.props.pageSize) }, () => {
       const { activeDescendant } = nextProps
+      if (activeDescendant === this.activeDescendant) return
       const { scrollableTarget } = this.state
       const activeLi = activeDescendant && document && document.getElementById(activeDescendant)
       if (activeLi && scrollableTarget) {

--- a/src/tree/index.js
+++ b/src/tree/index.js
@@ -49,7 +49,7 @@ class Tree extends Component {
     this.computeInstanceProps(nextProps)
     this.setState({ items: this.allVisibleNodes.slice(0, this.currentPage * this.props.pageSize) }, () => {
       const { activeDescendant } = nextProps
-      if (activeDescendant === this.activeDescendant) return
+      if (activeDescendant === this.props.activeDescendant) return
       const { scrollableTarget } = this.state
       const activeLi = activeDescendant && document && document.getElementById(activeDescendant)
       if (activeLi && scrollableTarget) {


### PR DESCRIPTION
Avoids changing scroll if the current active descendant is the same for the tree (on prop updates on tree).

Partially fixes #257

## Type of change
- [x] Bug fix