### PR TITLE
fix: Do not hide ancestor nodes if they match 🐛

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,10 +6,27 @@
   "configurations": [
     {
       "type": "node",
+      "request": "attach",
+      "name": "Attach by Process ID",
+      "processId": "${command:PickProcess}"
+    },
+    {
+      "type": "node",
       "request": "launch",
       "name": "webpack-dev-server",
       "program": "${workspaceRoot}/node_modules/webpack-dev-server/bin/webpack-dev-server.js",
       "cwd": "${workspaceFolder}/docs"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Run AVA test",
+      "program": "${workspaceFolder}/node_modules/ava/cli.js",
+      "autoAttachChildProcesses": true,
+      //"args": ["${file}", "--serial"],
+      // "args": ["${file}"],
+      "args": ["${workspaceFolder}\\src\\index.test.js", "--serial"],
+      "skipFiles": ["<node_internals>/**/*.js"]
     }
   ]
 }

--- a/src/tree-manager/index.js
+++ b/src/tree-manager/index.js
@@ -67,7 +67,7 @@ class TreeManager {
     if (id !== undefined) {
       const node = this.getNodeById(id)
       this.addParentsToTree(node._parent, tree)
-      node.hide = true
+      node.hide = node._isMatch ? node.hide : true
       node.matchInChildren = true
       tree.set(id, node)
     }
@@ -96,6 +96,10 @@ class TreeManager {
     matches.forEach(m => {
       const node = this.getNodeById(m)
       node.hide = false
+
+      // add a marker to tell `addParentsToTree` to not hide this node; even if it's an ancestor node
+      node._isMatch = true
+
       if (keepTreeOnSearch) {
         // add parent nodes first or else the tree won't be rendered in correct hierarchy
         this.addParentsToTree(node._parent, matchTree)

--- a/src/tree-manager/tests/index.test.js
+++ b/src/tree-manager/tests/index.test.js
@@ -604,3 +604,39 @@ test('should return children when search with `keepChildrenOnSearch`', t => {
   const nodes = ['i1', 'c1', 'c2']
   nodes.forEach(n => t.not(matchTree.get(n), undefined))
 })
+
+test('should not hide parent nodes if they match search term with `keepTreeOnSearch`', t => {
+  const tree = [
+    {
+      id: 'i1',
+      label: 'A top level item',
+      value: 'v1',
+      children: [
+        {
+          id: 'c1',
+          label: 'SeaRch me too',
+          value: 'l1v1',
+          children: [
+            {
+              id: 'c2',
+              label: 'search me, please!',
+              value: 'l2v1',
+            },
+          ],
+        },
+      ],
+    },
+  ]
+  const manager = new TreeManager({ data: tree })
+  const keepTreeOnSearch = true
+  const { allNodesHidden, tree: matchTree } = manager.filterTree('search me', keepTreeOnSearch)
+  t.false(allNodesHidden)
+  const nodes = ['c1', 'c2']
+  nodes.forEach(n => {
+    t.not(matchTree.get(n), undefined, `${n} should not be undefined.`)
+    t.false(manager.getNodeById(n).hide, `${n} should not be hidden.`)
+  })
+
+  const hiddenNodes = ['i1']
+  hiddenNodes.forEach(n => t.true(manager.getNodeById(n).hide, `${n} should not be visible.`))
+})


### PR DESCRIPTION
## What does it do?

Ancestor nodes, that contained match term, were always marked hidden or translucent if a child node contained the match term. This PR fixes that issue.

## Fixes # (issue)

Fixes #291 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] Updated documentation (if applicable)
- [X] Added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] My changes generate no new warnings
