### PR TITLE
feat: Added tagLabel option to make node and tag labels differ

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Data for rendering the tree select items. The object requires the following stru
   actions,        // optional: An array of extra action on the node (such as displaying an info icon or any custom icons/elements)
   dataset,        // optional: Allows data-* attributes to be set on the node and tag elements
   isDefaultValue, // optional: Indicate if a node is a default value. When true, the dropdown will automatically select the node(s) when there is no other selected node. Can be used on more than one node.
+  tagLabel,       // optional: tag label in case you need it to differ from the checkbox label
   ...             // optional: Any extra properties that you'd like to receive during `onChange` event
 }
 ```

--- a/src/input/index.js
+++ b/src/input/index.js
@@ -10,11 +10,11 @@ const cx = cn.bind(styles)
 
 const getTags = (tags = [], onDelete, readOnly, disabled, labelRemove) =>
   tags.map(tag => {
-    const { _id, label, tagClassName, dataset } = tag
+    const { _id, label, tagClassName, dataset, tagLabel } = tag
     return (
       <li className={cx('tag-item', tagClassName)} key={`tag-item-${_id}`} {...getDataset(dataset)}>
         <Tag
-          label={label}
+          label={tagLabel || label}
           id={_id}
           onDelete={onDelete}
           readOnly={readOnly}


### PR DESCRIPTION
## What does it do?

Adds a tagLabel prop for those use cases where you want to display something different in a tag label compared to the checkbox one.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] Updated documentation (if applicable)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ x ] My changes generate no new warnings
