### PR TITLE
feat: Adds selectable option

### DIFF
--- a/src/tree-node/index.js
+++ b/src/tree-node/index.js
@@ -73,6 +73,7 @@ class TreeNode extends PureComponent {
     showPartiallySelected: PropTypes.bool,
     readOnly: PropTypes.bool,
     clientId: PropTypes.string,
+    selectable: PropTypes.bool,
   }
 
   getAriaAttributes = () => {
@@ -113,6 +114,7 @@ class TreeNode extends PureComponent {
       showPartiallySelected,
       readOnly,
       clientId,
+      selectable,
     } = this.props
     const liCx = getNodeCx(this.props)
     const style = keepTreeOnSearch || !searchModeOn ? { paddingLeft: `${(_depth || 0) * 20}px` } : {}
@@ -135,6 +137,7 @@ class TreeNode extends PureComponent {
           showPartiallySelected={showPartiallySelected}
           readOnly={readOnly}
           clientId={clientId}
+          selectable={selectable}
         />
         <Actions actions={actions} onAction={onAction} id={_id} readOnly={readOnly} />
       </li>

--- a/src/tree-node/node-label.js
+++ b/src/tree-node/node-label.js
@@ -24,6 +24,7 @@ class NodeLabel extends PureComponent {
     onCheckboxChange: PropTypes.func,
     readOnly: PropTypes.bool,
     clientId: PropTypes.string,
+    selectable: PropTypes.bool,
   }
 
   handleCheckboxChange = e => {
@@ -42,7 +43,7 @@ class NodeLabel extends PureComponent {
   }
 
   render() {
-    const { mode, title, label, id, partial, checked } = this.props
+    const { mode, title, label, id, partial, checked, selectable = true } = this.props
     const { value, disabled, showPartiallySelected, readOnly, clientId } = this.props
     const nodeLabelProps = { className: 'node-label' }
 
@@ -61,13 +62,15 @@ class NodeLabel extends PureComponent {
         {mode === 'radioSelect' ? (
           <RadioButton name={clientId} className="radio-item" onChange={this.handleCheckboxChange} {...sharedProps} />
         ) : (
-          <Checkbox
-            name={id}
-            className={cx('checkbox-item', { 'simple-select': mode === 'simpleSelect' })}
-            indeterminate={showPartiallySelected && partial}
-            onChange={this.handleCheckboxChange}
-            {...sharedProps}
-          />
+          selectable && (
+            <Checkbox
+              name={id}
+              className={cx('checkbox-item', { 'simple-select': mode === 'simpleSelect' })}
+              indeterminate={showPartiallySelected && partial}
+              onChange={this.handleCheckboxChange}
+              {...sharedProps}
+            />
+          )
         )}
         <span {...nodeLabelProps}>{label}</span>
       </label>


### PR DESCRIPTION
fixes https://github.com/dowjones/react-dropdown-tree-select/issues/306

## What does it do?

Adds a `selectable` prop to avoid rendering checkbox when not needed without disabling it.

## Fixes # (issue)

Closes #306

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Updated documentation (if applicable)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes generate no new warnings
