### PR TITLE
fix: Change focus on mouse/checkbox toggle also #329

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -173,25 +173,29 @@ class DropdownTreeSelect extends Component {
   }
 
   onCheckboxChange = (id, checked, callback) => {
-    const { mode, keepOpenOnSelect } = this.props
+    const { mode, keepOpenOnSelect, clearSearchOnChange } = this.props
+    const { currentFocus, searchModeOn } = this.state
     this.treeManager.setNodeCheckedState(id, checked)
     let tags = this.treeManager.tags
     const isSingleSelect = ['simpleSelect', 'radioSelect'].indexOf(mode) > -1
     const showDropdown = isSingleSelect && !keepOpenOnSelect ? false : this.state.showDropdown
+    const currentFocusNode = currentFocus && this.treeManager.getNodeById(currentFocus)
+    const node = this.treeManager.getNodeById(id)
 
     if (!tags.length) {
       this.treeManager.restoreDefaultValues()
       tags = this.treeManager.tags
     }
 
-    const tree = this.state.searchModeOn ? this.treeManager.matchTree : this.treeManager.tree
+    const tree = searchModeOn ? this.treeManager.matchTree : this.treeManager.tree
     const nextState = {
       tree,
       tags,
       showDropdown,
+      currentFocus: id,
     }
 
-    if ((isSingleSelect && !showDropdown) || this.props.clearSearchOnChange) {
+    if ((isSingleSelect && !showDropdown) || clearSearchOnChange) {
       Object.assign(nextState, this.resetSearchState())
     }
 
@@ -199,10 +203,11 @@ class DropdownTreeSelect extends Component {
       document.removeEventListener('click', this.handleOutsideClick, false)
     }
 
+    keyboardNavigation.adjustFocusedProps(currentFocusNode, node)
     this.setState(nextState, () => {
       callback && callback(tags)
     })
-    this.props.onChange(this.treeManager.getNodeById(id), tags)
+    this.props.onChange(node, tags)
   }
 
   onAction = (nodeId, action) => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -120,7 +120,11 @@ test('notifies on checkbox change', t => {
   const { tree } = t.context
   const wrapper = shallow(<DropdownTreeSelect id={dropdownId} data={tree} onChange={handler} />)
   wrapper.instance().onCheckboxChange(node0._id, true)
-  t.true(handler.calledWithExactly({ ...node0, checked: true }, [{ ...node0, checked: true }]))
+  t.true(
+    handler.calledWithExactly({ ...node0, _focused: true, checked: true }, [
+      { ...node0, _focused: true, checked: true },
+    ])
+  )
 })
 
 test('notifies on tag removal', t => {
@@ -128,7 +132,7 @@ test('notifies on tag removal', t => {
   const { tree } = t.context
   const wrapper = shallow(<DropdownTreeSelect id={dropdownId} data={tree} onChange={handler} />)
   wrapper.instance().onTagRemove(node0._id)
-  t.true(handler.calledWithExactly({ ...node0, checked: false }, []))
+  t.true(handler.calledWithExactly({ ...node0, _focused: true, checked: false }, []))
 })
 
 test('sets search mode on input change', t => {

--- a/src/tree-manager/keyboardNavigation.js
+++ b/src/tree-manager/keyboardNavigation.js
@@ -160,14 +160,20 @@ const getNextFocusAfterTagDelete = (deletedId, prevTags, tags, fallback) => {
 
 const handleFocusNavigationkey = (tree, action, prevFocus, getNodeById, markSubTreeOnNonExpanded) => {
   const newFocus = keyboardNavigation.getNextFocus(tree, prevFocus, action, getNodeById, markSubTreeOnNonExpanded)
+  keyboardNavigation.adjustFocusedProps(prevFocus, newFocus)
+  if (newFocus) {
+    return newFocus._id
+  }
+  return prevFocus && prevFocus._id
+}
+
+const adjustFocusedProps = (prevFocus, newFocus) => {
   if (prevFocus && newFocus && prevFocus._id !== newFocus._id) {
     prevFocus._focused = false
   }
   if (newFocus) {
     newFocus._focused = true
-    return newFocus._id
   }
-  return prevFocus && prevFocus._id
 }
 
 const handleToggleNavigationkey = (action, prevFocus, readOnly, onToggleChecked, onToggleExpanded) => {
@@ -186,6 +192,7 @@ const keyboardNavigation = {
   getNextFocusAfterTagDelete,
   handleFocusNavigationkey,
   handleToggleNavigationkey,
+  adjustFocusedProps,
 }
 
 export default keyboardNavigation


### PR DESCRIPTION
## What does it do?

We keep track of current focus on keyboard navigation but we don't update it on mouse clicks (checkbox toggle).

Fixes #329.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)