### PR TITLE
fix: Also check disabled on node-level  #332

### DIFF
--- a/src/tags/index.js
+++ b/src/tags/index.js
@@ -19,7 +19,7 @@ const getTags = (tags = [], onDelete, readOnly, disabled, labelRemove) =>
           id={_id}
           onDelete={onDelete}
           readOnly={readOnly}
-          disabled={disabled}
+          disabled={disabled || tag.disabled}
           labelRemove={labelRemove}
         />
       </li>


### PR DESCRIPTION
## What does it do?

The disabled state of a single node is not considered when rendering tag remove causing the checkbox to be altered on click. This checks the overall dropdown or the nodes disabled state to avoid this.

Fixes #332

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)