### PR TITLE
feat: Add new option expandAllAncestors

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ A lightweight and fast control to render a select component that can display hie
     - [simpleSelect](#simpleselect)
     - [radioSelect](#radioselect)
   - [showPartiallySelected](#showpartiallyselected)
+  - [expandAllAncestors](#expandAllAncestors)
   - [showDropdown](#showdropdown)
     - [initial](#initial)
     - [always](#always)
@@ -362,6 +363,12 @@ Like `simpleSelect`, you can only select one value; but keeps the tree/children 
 Type: `bool` (default: `false`)
 
 If set to true, shows checkboxes in a partial state when one, but not all of their children are selected. Allows styling of partially selected nodes as well, by using [:indeterminate](https://developer.mozilla.org/en-US/docs/Web/CSS/:indeterminate) pseudo class. Simply add desired styles to `.node.partial .checkbox-item:indeterminate { ... }` in your CSS.
+
+### expandAllAncestors
+
+Type: `bool` (default: `false`)
+
+If set to true, it expands all ancestors of a selected node
 
 ### showDropdown
 

--- a/docs/src/stories/Options/index.js
+++ b/docs/src/stories/Options/index.js
@@ -17,6 +17,7 @@ class WithOptions extends PureComponent {
       mode: 'multiSelect',
       inlineSearchInput: false,
       showPartiallySelected: false,
+      expandAllAncestors: false,
       disabled: false,
       readOnly: false,
       hierarchical: false,
@@ -44,6 +45,7 @@ class WithOptions extends PureComponent {
       keepOpenOnSelect,
       mode,
       showPartiallySelected,
+      expandAllAncestors,
       disabled,
       readOnly,
       showDropdown,
@@ -113,6 +115,12 @@ class WithOptions extends PureComponent {
             checked={showPartiallySelected}
             onChange={this.onOptionsChange}
           />
+          <Checkbox
+            label="Expand all ancestors of a selected node"
+            value="expandAllAncestors"
+            checked={expandAllAncestors}
+            onChange={this.onOptionsChange}
+          />
           <Checkbox label="Disabled" value="disabled" checked={disabled} onChange={this.onOptionsChange} />
           <Checkbox label="Read Only" value="readOnly" checked={readOnly} onChange={this.onOptionsChange} />
         </div>
@@ -127,6 +135,7 @@ class WithOptions extends PureComponent {
             keepTreeOnSearch={keepTreeOnSearch}
             keepOpenOnSelect={keepOpenOnSelect}
             mode={mode}
+            expandAllAncestors={expandAllAncestors}
             showPartiallySelected={showPartiallySelected}
             disabled={disabled}
             readOnly={readOnly}

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ class DropdownTreeSelect extends Component {
     onBlur: PropTypes.func,
     mode: PropTypes.oneOf(['multiSelect', 'simpleSelect', 'radioSelect', 'hierarchical']),
     showPartiallySelected: PropTypes.bool,
+    expandAllAncestors: PropTypes.bool,
     disabled: PropTypes.bool,
     readOnly: PropTypes.bool,
     id: PropTypes.string,
@@ -67,11 +68,12 @@ class DropdownTreeSelect extends Component {
     this.clientId = props.id || clientIdGenerator.get(this)
   }
 
-  initNewProps = ({ data, mode, showDropdown, showPartiallySelected, searchPredicate }) => {
+  initNewProps = ({ data, mode, showDropdown, showPartiallySelected, expandAllAncestors, searchPredicate }) => {
     this.treeManager = new TreeManager({
       data,
       mode,
       showPartiallySelected,
+      expandAllAncestors,
       rootPrefixId: this.clientId,
       searchPredicate,
     })

--- a/src/tree-manager/flatten-tree.js
+++ b/src/tree-manager/flatten-tree.js
@@ -1,6 +1,7 @@
 import getPartialState from './getPartialState'
 
 import { isEmpty } from '../utils'
+import getExpanded from './getExpanded'
 
 /**
  * Converts a nested node into an associative array with pointers to child and parent nodes
@@ -168,10 +169,12 @@ const tree = [
  * @param  {[bool]} simple            Whether its in Single select mode (simple dropdown)
  * @param  {[bool]} radio             Whether its in Radio select mode (radio dropdown)
  * @param  {[bool]} showPartialState  Whether to show partially checked state
+ * @param  {[bool]} expandAllAncestors  Whether to expand partially checked state
+ * @param  {[bool]} hierarchical
  * @param  {[string]} rootPrefixId    The prefix to use when setting root node ids
  * @return {object}                   The flattened list
  */
-function flattenTree({ tree, simple, radio, showPartialState, hierarchical, rootPrefixId }) {
+function flattenTree({ tree, simple, radio, showPartialState, expandAllAncestors, hierarchical, rootPrefixId }) {
   const forest = Array.isArray(tree) ? tree : [tree]
 
   // eslint-disable-next-line no-use-before-define
@@ -180,6 +183,7 @@ function flattenTree({ tree, simple, radio, showPartialState, hierarchical, root
     simple,
     radio,
     showPartialState,
+    expandAllAncestors,
     hierarchical,
     rootPrefixId,
   })
@@ -211,6 +215,7 @@ function walkNodes({
   simple,
   radio,
   showPartialState,
+  expandAllAncestors,
   hierarchical,
   rootPrefixId,
   _rv = { list: new Map(), defaultValues: [], singleSelectedNode: null },
@@ -260,6 +265,7 @@ function walkNodes({
         depth: depth + 1,
         radio,
         showPartialState,
+        expandAllAncestors,
         hierarchical,
         _rv,
       })
@@ -270,6 +276,14 @@ function walkNodes({
         // re-check if all children are checked. if so, check thyself
         if (!single && !isEmpty(node.children) && node.children.every(c => c.checked)) {
           node.checked = true
+        }
+      }
+      if (expandAllAncestors && !node.checked) {
+        node.expanded = getPartialState(node) || getExpanded(node)
+
+        // re-check if all children are checked. if so, expand thyself
+        if (!isEmpty(node.children) && node.children.every(c => c.checked)) {
+          node.expanded = true
         }
       }
 

--- a/src/tree-manager/getExpanded.js
+++ b/src/tree-manager/getExpanded.js
@@ -1,0 +1,6 @@
+import partial from 'array.partial'
+
+const identity = c => c
+
+export default (node, childProp = 'children', childSelector = identity) =>
+  partial(node[childProp], c => childSelector(c).expanded)

--- a/src/tree-manager/index.js
+++ b/src/tree-manager/index.js
@@ -5,7 +5,7 @@ import nodeVisitor from './nodeVisitor'
 import keyboardNavigation, { FocusActionNames } from './keyboardNavigation'
 
 class TreeManager {
-  constructor({ data, mode, showPartiallySelected, rootPrefixId, searchPredicate }) {
+  constructor({ data, mode, showPartiallySelected, expandAllAncestors, rootPrefixId, searchPredicate }) {
     this._src = data
     this.simpleSelect = mode === 'simpleSelect'
     this.radioSelect = mode === 'radioSelect'
@@ -16,6 +16,7 @@ class TreeManager {
       simple: this.simpleSelect,
       radio: this.radioSelect,
       showPartialState: showPartiallySelected,
+      expandAllAncestors,
       hierarchical: this.hierarchical,
       rootPrefixId,
     })

--- a/src/tree-manager/tests/expandAllAncestors.test.js
+++ b/src/tree-manager/tests/expandAllAncestors.test.js
@@ -1,0 +1,39 @@
+import test from 'ava'
+import TreeManager from '..'
+import {
+  grandParent,
+  parent1,
+  parent2,
+  childrenOfParent1,
+  childrenOfParent2,
+  assertTreeInExpectedState,
+} from './partial-setup'
+
+test.beforeEach(t => {
+  t.context.tree = {
+    id: grandParent,
+    children: [
+      {
+        id: parent1,
+        children: [{ id: '1-1-1' }, { id: '1-1-2' }],
+      },
+      {
+        id: parent2,
+        children: [{ id: '1-2-1' }, { id: '1-2-2' }, { id: '1-2-3' }],
+      },
+    ],
+  }
+})
+
+test('should set expanded state if a child is checked', t => {
+  const { tree } = t.context
+  tree.children[0].checked = true
+  const manager = new TreeManager({ data: tree, mode: 'multiSelect', expandAllAncestors: true })
+
+  const expected = {
+    checked: [parent1, ...childrenOfParent1],
+    expanded: [grandParent],
+    unexpanded: [parent1, ...childrenOfParent1, parent2, ...childrenOfParent2],
+  }
+  assertTreeInExpectedState(t, manager, expected)
+})

--- a/src/tree-manager/tests/partial-setup.js
+++ b/src/tree-manager/tests/partial-setup.js
@@ -9,10 +9,12 @@ export const childrenOfParent2 = ['1-2-1', '1-2-2', '1-2-3']
 export const children = [...childrenOfParent1, ...childrenOfParent2]
 
 export const assertTreeInExpectedState = (t, manager, expected) => {
-  const { checked = [], partial = [], unchecked = [], nonPartial = [] } = expected
+  const { checked = [], partial = [], unchecked = [], nonPartial = [], expanded = [], unexpanded = [] } = expected
 
   checked.forEach(c => t.truthy(manager.getNodeById(c).checked, `Expected node ${c} to be in checked state`))
   partial.forEach(c => t.truthy(manager.getNodeById(c).partial, `Expected node ${c} to be in partial state`))
   unchecked.forEach(c => t.falsy(manager.getNodeById(c).checked, `Expected node ${c} to be in unchecked state`))
   nonPartial.forEach(c => t.falsy(manager.getNodeById(c).partial, `Expected node ${c} to be in non-partial state`))
+  expanded.forEach(c => t.truthy(manager.getNodeById(c).expanded, `Expected node ${c} to be in expanded state`))
+  unexpanded.forEach(c => t.falsy(manager.getNodeById(c).expanded, `Expected node ${c} to be in unexpanded state`))
 }


### PR DESCRIPTION
## What does it do?

Added new option which expands by default the parent nodes of a checked child.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Updated documentation (if applicable)
- [x] Added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
