### PR TITLE
fix: IE11 doesn't support Array.findIndex

### DIFF
--- a/src/tree-manager/keyboardNavigation.js
+++ b/src/tree-manager/keyboardNavigation.js
@@ -146,7 +146,15 @@ const getNextFocus = (tree, prevFocus, action, getNodeById, markSubTreeOnNonExpa
 
 const getNextFocusAfterTagDelete = (deletedId, prevTags, tags, fallback) => {
   // Sets new focus to next tag or returns fallback
-  let index = prevTags && prevTags.some(t => t._id === deletedId)
+  let index = -1
+  if (prevTags) {
+    prevTags.map((t, i) => {
+      if (t.key === deletedId) {
+        index = i + 1
+      }
+      return false
+    })
+  }
   if (index < 0 || !tags.length) return fallback
 
   index = tags.length > index ? index : tags.length - 1

--- a/src/tree-manager/keyboardNavigation.js
+++ b/src/tree-manager/keyboardNavigation.js
@@ -146,7 +146,7 @@ const getNextFocus = (tree, prevFocus, action, getNodeById, markSubTreeOnNonExpa
 
 const getNextFocusAfterTagDelete = (deletedId, prevTags, tags, fallback) => {
   // Sets new focus to next tag or returns fallback
-  let index = prevTags && prevTags.findIndex(t => t._id === deletedId)
+  let index = prevTags && prevTags.some(t => t._id === deletedId)
   if (index < 0 || !tags.length) return fallback
 
   index = tags.length > index ? index : tags.length - 1

--- a/src/tree/index.js
+++ b/src/tree/index.js
@@ -69,7 +69,13 @@ class Tree extends Component {
     this.totalPages = Math.ceil(this.allVisibleNodes.length / this.props.pageSize)
     if (checkActiveDescendant && props.activeDescendant) {
       const currentId = props.activeDescendant.replace(/_li$/, '')
-      const focusIndex = this.allVisibleNodes.some(n => n.key === currentId) + 1
+      let focusIndex = -1
+      this.allVisibleNodes.map((n, i) => {
+        if (n.key === currentId) {
+          focusIndex = i + 1
+        }
+        return false
+      })
       this.currentPage = focusIndex > 0 ? Math.ceil(focusIndex / this.props.pageSize) : 1
     }
   }

--- a/src/tree/index.js
+++ b/src/tree/index.js
@@ -69,7 +69,7 @@ class Tree extends Component {
     this.totalPages = Math.ceil(this.allVisibleNodes.length / this.props.pageSize)
     if (checkActiveDescendant && props.activeDescendant) {
       const currentId = props.activeDescendant.replace(/_li$/, '')
-      const focusIndex = this.allVisibleNodes.findIndex(n => n.key === currentId) + 1
+      const focusIndex = this.allVisibleNodes.some(n => n.key === currentId) + 1
       this.currentPage = focusIndex > 0 ? Math.ceil(focusIndex / this.props.pageSize) : 1
     }
   }


### PR DESCRIPTION
## What does it do?

resolved findIndex() method issue can't support on internet explorer,
## Fixes # (issue)

findIndex method can't support on IE browser #347

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
