### PR TITLE
fix: Remove search-specific properties from nodes on clear

### DIFF
--- a/src/tree-manager/index.js
+++ b/src/tree-manager/index.js
@@ -63,11 +63,15 @@ class TreeManager {
     return matches
   }
 
-  addParentsToTree(id, tree) {
+  addParentsToTree(id, tree, matches) {
     if (id !== undefined) {
+      if (matches && matches.includes(id)) {
+        // if a parent is found by search anyways, don't display it as a parent here
+        return
+      }
       const node = this.getNodeById(id)
       this.addParentsToTree(node._parent, tree)
-      node.hide = node._isMatch ? node.hide : true
+      node.hide = true
       node.matchInChildren = true
       tree.set(id, node)
     }
@@ -97,12 +101,9 @@ class TreeManager {
       const node = this.getNodeById(m)
       node.hide = false
 
-      // add a marker to tell `addParentsToTree` to not hide this node; even if it's an ancestor node
-      node._isMatch = true
-
       if (keepTreeOnSearch) {
         // add parent nodes first or else the tree won't be rendered in correct hierarchy
-        this.addParentsToTree(node._parent, matchTree)
+        this.addParentsToTree(node._parent, matchTree, matches)
       }
       matchTree.set(m, node)
       if (keepTreeOnSearch && keepChildrenOnSearch) {

--- a/src/tree-manager/index.js
+++ b/src/tree-manager/index.js
@@ -70,7 +70,7 @@ class TreeManager {
         return
       }
       const node = this.getNodeById(id)
-      this.addParentsToTree(node._parent, tree)
+      this.addParentsToTree(node._parent, tree, matches)
       node.hide = true
       node.matchInChildren = true
       tree.set(id, node)


### PR DESCRIPTION
## What does it do?

The "_isMatch" property is never cleared, so non-matching parents will still be shown (not greyed-out) and can be focused (i.e. navigation with the arrow keys)..

This fixes that issue by setting all parents to hidden, unless they themselves are a match. They will still be shown with keepTreeOnSearch, because the "matchInChildren" property is set to true.

## Fixes # (issue)

No issueNumber

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] Updated documentation (if applicable)
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
