### PR TITLE
feat: Focus first match on search

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -142,17 +142,25 @@ class DropdownTreeSelect extends Component {
   }
 
   onInputChange = value => {
-    const { allNodesHidden, tree } = this.treeManager.filterTree(
+    const { allNodesHidden, tree, matches } = this.treeManager.filterTree(
       value,
       this.props.keepTreeOnSearch,
       this.props.keepChildrenOnSearch
     )
     const searchModeOn = value.length > 0
 
+    const { currentFocus } = this.state
+    if (!matches.includes(currentFocus)) {
+      const currentFocusNode = currentFocus && this.treeManager.getNodeById(currentFocus)
+      const firstMatchNode = this.treeManager.getNodeById(matches[0])
+      keyboardNavigation.adjustFocusedProps(currentFocusNode, firstMatchNode)
+    }
+
     this.setState({
       tree,
       searchModeOn,
       allNodesHidden,
+      currentFocus: matches.includes(currentFocus) ? currentFocus : matches[0],
     })
   }
 

--- a/src/tree-manager/index.js
+++ b/src/tree-manager/index.js
@@ -117,7 +117,7 @@ class TreeManager {
     // this is the least intrusive way of fixing #190
     this.matchTree = matchTree
 
-    return { allNodesHidden, tree: matchTree }
+    return { allNodesHidden, tree: matchTree, matches }
   }
 
   restoreNodes() {


### PR DESCRIPTION
## What does it do?

When searching, if the current focus is not a match, it will focus the first match.

## Fixes # (issue)

No issueNumber

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Updated documentation (if applicable)
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
