### PR TITLE
fix: Clear partial status of previous radio select parents

### DIFF
--- a/src/tree-manager/index.js
+++ b/src/tree-manager/index.js
@@ -141,12 +141,22 @@ class TreeManager {
 
     // if id is same as previously selected node, then do nothing (since it's state is already set correctly by setNodeCheckedState)
     // but if they ar not same, then toggle the previous one
-    if (prevChecked && prevChecked !== id) this.getNodeById(prevChecked).checked = false
+    if (prevChecked && prevChecked !== id) {
+      const prevNode = this.getNodeById(prevChecked)
+      prevNode.checked = false
+      // if radioSelect, then we need to remove the partial state from parents of previous node
+      if (this.radioSelect && this.showPartialState) this.partialCheckParents(prevNode)
+    }
 
     this.currentChecked = checked ? id : null
   }
 
   setNodeCheckedState(id, checked) {
+    // radioSelect must be done before setting node checked, to avoid conflicts with partialCheckParents
+    // this only occurs when selecting the parent of a previously selected child when the parent also has a parent
+    if (this.radioSelect) {
+      this.togglePreviousChecked(id, checked)
+    }
     const node = this.getNodeById(id)
     node.checked = checked
 
@@ -158,7 +168,6 @@ class TreeManager {
     if (this.simpleSelect) {
       this.togglePreviousChecked(id, checked)
     } else if (this.radioSelect) {
-      this.togglePreviousChecked(id, checked)
       if (this.showPartialState) {
         this.partialCheckParents(node)
       }

--- a/src/tree-manager/index.js
+++ b/src/tree-manager/index.js
@@ -154,9 +154,8 @@ class TreeManager {
   setNodeCheckedState(id, checked) {
     // radioSelect must be done before setting node checked, to avoid conflicts with partialCheckParents
     // this only occurs when selecting the parent of a previously selected child when the parent also has a parent
-    if (this.radioSelect) {
-      this.togglePreviousChecked(id, checked)
-    }
+    if (this.radioSelect) this.togglePreviousChecked(id, checked)
+
     const node = this.getNodeById(id)
     node.checked = checked
 

--- a/src/tree-manager/tests/partialSelect.test.js
+++ b/src/tree-manager/tests/partialSelect.test.js
@@ -85,3 +85,72 @@ test('should not set partial state if all of the children are checked', t => {
   }
   assertTreeInExpectedState(t, manager, expected)
 })
+
+test('should set partial state of radioSelect', t => {
+  const { tree } = t.context
+  tree.children[0].checked = true
+
+  const manager = new TreeManager({ data: tree, mode: 'radioSelect', showPartiallySelected: true })
+
+  const expected = {
+    checked: [parent1],
+    nonPartial: [...parents, ...children],
+    partial: [grandParent],
+    unchecked: [parent2, ...childrenOfParent2, ...childrenOfParent1],
+  }
+  assertTreeInExpectedState(t, manager, expected)
+})
+
+test('should clear previous partial state of radioSelect on change', t => {
+  const { tree } = t.context
+  const manager = new TreeManager({ data: tree, mode: 'radioSelect', showPartiallySelected: true })
+
+  // first select a node
+  manager.setNodeCheckedState(tree.children[0].children[0].id, true)
+
+  const expected1 = {
+    checked: [tree.children[0].children[0].id],
+    nonPartial: [parent2, ...childrenOfParent2],
+    partial: [grandParent, parent1],
+    unchecked: [parent2, ...childrenOfParent2],
+  }
+  assertTreeInExpectedState(t, manager, expected1)
+
+  // then select a node from another parent
+  manager.setNodeCheckedState(tree.children[1].id, true)
+
+  const expected2 = {
+    checked: [parent2],
+    nonPartial: [...parents, ...children],
+    partial: [grandParent],
+    unchecked: [parent1, ...childrenOfParent1, ...childrenOfParent2],
+  }
+  assertTreeInExpectedState(t, manager, expected2)
+})
+
+test('should correctly set partial state of radioSelect when selecting a parent of a previously selected child', t => {
+  const { tree } = t.context
+  const manager = new TreeManager({ data: tree, mode: 'radioSelect', showPartiallySelected: true })
+
+  // first select a grandchild
+  manager.setNodeCheckedState(tree.children[1].children[1].id, true)
+
+  const expected1 = {
+    checked: [tree.children[1].children[1].id],
+    nonPartial: [parent1, ...childrenOfParent1],
+    partial: [grandParent, parent2],
+    unchecked: [parent1, ...childrenOfParent1],
+  }
+  assertTreeInExpectedState(t, manager, expected1)
+
+  // then select its parent
+  manager.setNodeCheckedState(tree.children[1].id, true)
+
+  const expected2 = {
+    checked: [parent2],
+    nonPartial: [...parents, ...children],
+    partial: [grandParent],
+    unchecked: [parent1, ...childrenOfParent1, ...childrenOfParent2],
+  }
+  assertTreeInExpectedState(t, manager, expected2)
+})


### PR DESCRIPTION
## What does it do?

Clears the partial status from the parents of the previous node, when using radioSelect.

## Fixes # (issue)

Fixes #372

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] Updated documentation (if applicable)
- [x] Added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
