### PR TITLE
fix: Delayed focused update when receiving data changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [npm-image]: http://img.shields.io/npm/v/react-dropdown-tree-select.svg?style=flat-square
 [npm-url]: http://npmjs.org/package/react-dropdown-tree-select
-[travis-image]: https://img.shields.io/travis/dowjones/react-dropdown-tree-select.svg?style=flat-square
+[travis-image]: https://travis-ci.org/dowjones/react-dropdown-tree-select.svg?branch=develop
 [travis-url]: https://travis-ci.org/dowjones/react-dropdown-tree-select
 [coveralls-image]: https://img.shields.io/coveralls/dowjones/react-dropdown-tree-select.svg?style=flat-square
 [coveralls-url]: https://coveralls.io/r/dowjones/react-dropdown-tree-select?branch=master

--- a/src/index.js
+++ b/src/index.js
@@ -75,15 +75,16 @@ class DropdownTreeSelect extends Component {
       rootPrefixId: this.clientId,
       searchPredicate,
     })
-    // Restore focus-state
-    const currentFocusNode = this.state.currentFocus && this.treeManager.getNodeById(this.state.currentFocus)
-    if (currentFocusNode) {
-      currentFocusNode._focused = true
-    }
-    this.setState(prevState => ({
-      showDropdown: /initial|always/.test(showDropdown) || prevState.showDropdown === true,
-      ...this.treeManager.getTreeAndTags(),
-    }))
+    this.setState(prevState => {
+      const currentFocusNode = prevState.currentFocus && this.treeManager.getNodeById(prevState.currentFocus)
+      if (currentFocusNode) {
+        currentFocusNode._focused = true
+      }
+      return {
+        showDropdown: /initial|always/.test(showDropdown) || prevState.showDropdown === true,
+        ...this.treeManager.getTreeAndTags(),
+      }
+    })
   }
 
   resetSearchState = () => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -318,30 +318,19 @@ test('appends selected tags to aria-labelledby with text label', t => {
 })
 
 test('select correct focused node when using external state data container', t => {
-  class DropdownContainer extends React.Component {
-    state = {
-      data: [
-        {
-          label: 'All data',
-          value: '0',
-        },
-        {
-          label: 'iWay',
-          value: '1',
-        },
-      ],
-    }
-    handleChange = ({ value, checked }) => {
-      this.setState(prevState => {
-        const { data } = prevState
-        data[value].checked = checked
-        return { data }
-      })
-    }
-    render() {
-      return <DropdownTreeSelect id={dropdownId} data={this.state.data} onChange={this.handleChange} />
-    }
-  }
+  let data = [
+    {
+      label: 'All data',
+      value: '0',
+      checked: false,
+    },
+    {
+      label: 'iWay',
+      value: '1',
+      checked: false,
+    },
+  ]
+  const wrapper = mount(<DropdownTreeSelect id={dropdownId} data={data} />)
   const nodeAllData = {
     _id: `${dropdownId}-0`,
     _depth: 0,
@@ -350,16 +339,21 @@ test('select correct focused node when using external state data container', t =
     children: undefined,
     actions: [action],
   }
-  const wrapper = mount(<DropdownContainer />)
-  const DropdownTreeSelectInstance = wrapper.find('DropdownTreeSelect')
-  DropdownTreeSelectInstance.instance().onCheckboxChange(nodeAllData._id, true)
-  t.deepEqual(DropdownTreeSelectInstance.state().currentFocus, nodeAllData._id)
-  t.deepEqual(DropdownTreeSelectInstance.state().tree.get(nodeAllData._id), {
-    _depth: 0,
-    _focused: true,
-    _id: 'rdts-0',
-    checked: true,
-    label: 'All data',
-    value: '0',
+  wrapper.instance().onCheckboxChange(nodeAllData._id, true)
+  //simulate external change to the data props.
+  wrapper.setProps({
+    data: [
+      {
+        label: 'All data',
+        value: '0',
+        checked: true,
+      },
+      {
+        label: 'iWay',
+        value: '1',
+        checked: false,
+      },
+    ],
   })
+  t.deepEqual(wrapper.state().currentFocus, nodeAllData._id)
 })

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -316,3 +316,50 @@ test('appends selected tags to aria-labelledby with text label', t => {
   t.deepEqual(wrapper.find('.dropdown-trigger').prop('aria-labelledby'), 'rdts_trigger rdts-0_tag')
   t.deepEqual(wrapper.find('.dropdown-trigger').prop('aria-label'), 'hello world')
 })
+
+test('select correct focused node when using external state data container', t => {
+  class DropdownContainer extends React.Component {
+    state = {
+      data: [
+        {
+          label: 'All data',
+          value: '0',
+        },
+        {
+          label: 'iWay',
+          value: '1',
+        },
+      ],
+    }
+    handleChange = ({ value, checked }) => {
+      this.setState(prevState => {
+        const { data } = prevState
+        data[value].checked = checked
+        return { data }
+      })
+    }
+    render() {
+      return <DropdownTreeSelect id={dropdownId} data={this.state.data} onChange={this.handleChange} />
+    }
+  }
+  const nodeAllData = {
+    _id: `${dropdownId}-0`,
+    _depth: 0,
+    label: 'All data',
+    value: '0',
+    children: undefined,
+    actions: [action],
+  }
+  const wrapper = mount(<DropdownContainer />)
+  const DropdownTreeSelectInstance = wrapper.find('DropdownTreeSelect')
+  DropdownTreeSelectInstance.instance().onCheckboxChange(nodeAllData._id, true)
+  t.deepEqual(DropdownTreeSelectInstance.state().currentFocus, nodeAllData._id)
+  t.deepEqual(DropdownTreeSelectInstance.state().tree.get(nodeAllData._id), {
+    _depth: 0,
+    _focused: true,
+    _id: 'rdts-0',
+    checked: true,
+    label: 'All data',
+    value: '0',
+  })
+})


### PR DESCRIPTION
## What does it do?
When using controlled data, if the data changes the focused node will be the latest one (the one before, first one is "null").

## Fixes # (issue)
Take the latest state moving the get Focused functionality inside the setState, this ensure to use the latest one.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Updated documentation (if applicable)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes generate no new warnings
