### PR TITLE
feat: Add prop to skip navigation on nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Data for rendering the tree select items. The object requires the following stru
   expanded,       // optional: If true, the node is expanded (children of children nodes are not expanded by default unless children nodes also have expanded: true).
   className,      // optional: Additional css class for the node. This is helpful to style the nodes your way
   tagClassName,   // optional: Css class for the corresponding tag. Use this to add custom style the pill corresponding to the node.
+  disableNavitaion, //optional: Allows to slip the keyboard navigation on this node.
   actions,        // optional: An array of extra action on the node (such as displaying an info icon or any custom icons/elements)
   dataset,        // optional: Allows data-* attributes to be set on the node and tag elements
   isDefaultValue, // optional: Indicate if a node is a default value. When true, the dropdown will automatically select the node(s) when there is no other selected node. Can be used on more than one node.

--- a/src/index.keyboardNav.test.js
+++ b/src/index.keyboardNav.test.js
@@ -52,6 +52,27 @@ test('other key presses does not open dropdown on keyboardNavigation', t => {
   })
 })
 
+test('should skip navigation on a node with disableNavigation = true', t => {
+  const tree = [
+    {
+      label: 'All data',
+      value: '0',
+      disableNavigation: true,
+    },
+    {
+      label: 'iWay',
+      value: '1',
+    },
+    {
+      label: 'KDB',
+      value: '2',
+    },
+  ]
+  const wrapper = mount(<DropdownTreeSelect data={tree} />)
+  triggerOnKeyboardKeyDown(wrapper, ['ArrowDown', 'ArrowDown'])
+  t.deepEqual(wrapper.find('li.focused').text(), 'KDB')
+})
+
 test('can navigate and focus child on keyboardNavigation', t => {
   const wrapper = mount(<DropdownTreeSelect data={tree} />)
   triggerOnKeyboardKeyDown(wrapper, [

--- a/src/tree-manager/nodeVisitor.js
+++ b/src/tree-manager/nodeVisitor.js
@@ -29,7 +29,7 @@ const getVisibleNodes = (tree, getItemById, markSubTreeOnNonExpanded) =>
     if (markSubTreeOnNonExpanded && node._children && node._children.length && node.expanded !== true) {
       markSubTreeVisited(node, visited, getItemById)
     }
-    return !node.hide
+    return !node.hide && !node.disableNavigation
   })
 
 const nodeVisitor = {


### PR DESCRIPTION
## What does it do?

Currently if I want to hide a node, I can do this with css, but the keyboard feature is able to reach those nodes. We cannot use the "hide" prop in each node, since it is overwritten when "restoringDefaults".

## Fixes # (issue)

Add a custom/optional prop to the nodes to disable keyboard navigation on them.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] Updated documentation (if applicable)
- [x] Added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] My changes generate no new warnings
