### PR TITLE
fix: action click node focus

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -212,7 +212,17 @@ class DropdownTreeSelect extends Component {
   }
 
   onAction = (nodeId, action) => {
-    this.props.onAction(this.treeManager.getNodeById(nodeId), action)
+    const { currentFocus } = this.state
+    const { searchModeOn } = this.props
+    const currentFocusNode = currentFocus && this.treeManager.getNodeById(currentFocus)
+    const node = this.treeManager.getNodeById(nodeId)
+    const tree = searchModeOn ? this.treeManager.matchTree : this.treeManager.tree
+    keyboardNavigation.adjustFocusedProps(currentFocusNode, node)
+    this.setState({
+      tree,
+      currentFocus: nodeId,
+    })
+    this.props.onAction(node, action)
   }
 
   onInputFocus = () => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -104,7 +104,15 @@ test('notifies on action', t => {
   const { tree } = t.context
   const wrapper = mount(<DropdownTreeSelect id={dropdownId} data={tree} onAction={handler} showDropdown="initial" />)
   wrapper.find('i.fa-ban').simulate('click')
-  t.true(handler.calledWithExactly(node0, action))
+  t.true(handler.calledWithExactly({ ...node0, _focused: true }, action))
+})
+
+test('focus on action node', t => {
+  const handler = spy()
+  const { tree } = t.context
+  const wrapper = mount(<DropdownTreeSelect id={dropdownId} data={tree} onAction={handler} showDropdown="initial" />)
+  wrapper.find('i.fa-ban').simulate('click')
+  t.deepEqual(wrapper.state().currentFocus, node0._id)
 })
 
 test('notifies on node toggle', t => {


### PR DESCRIPTION
## What does it do?
When clicking a node on the action section, it is not focused or still focuses on the previous one. This is confusing.

## What this PR do?
Update the tree manager with the current node where the action was clicked with the _focused correct value.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Updated documentation (if applicable)
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes 
Note: I had to update one of the tests since the returned node on the callback has the _focused value.
- [ ] My changes generate no new warnings
