### PR TITLE
fix: Make tests run in actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           node-version: 12.x
       - run: yarn install --ignore-engines
       - run: yarn lint:nofix
+      - run: yarn test
       # 💀💀💀💀cannot run coveralls since GH won't pass COVERALLS_REPO_TOKEN to forks; so any PRs from external contributors would fail
       # - run: yarn coveralls
       #   env:


### PR DESCRIPTION
## What does it do?

This makes `yarn test` run on PullRequests.

I think it is good, and as I saw that somehow `coveralls` cannot run, it would be good to have tests run at least.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Updated documentation (if applicable)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes generate no new warnings
