### PR TITLE
Null check for non existing childre to not write aria-expanded false …

### DIFF
--- a/src/tree-node/index.js
+++ b/src/tree-node/index.js
@@ -82,7 +82,9 @@ class TreeNode extends PureComponent {
     if (mode !== 'simpleSelect') {
       attributes['aria-checked'] = partial ? 'mixed' : checked
       attributes['aria-level'] = (_depth || 0) + 1
-      attributes['aria-expanded'] = _children && (expanded ? 'true' : 'false')
+      _children !== undefined && _children.length > 0
+        ? (attributes['aria-expanded'] = _children && (expanded ? 'true' : 'false'))
+        : null
     }
     return attributes
   }


### PR DESCRIPTION
…so that screen readers do not read that the level is closed

## What does it do?

Null check for children of certain level to not write out "aria-expanded=false" since screen readers reads the level to be closed when there is no children beneath the current parent.

## Fixes # (issue)

No recorded issue.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [No ] I have performed a self-review of my own code
- [Yes] I have commented my code, particularly in hard-to-understand areas
- [No] Updated documentation (if applicable)
- [No] Added tests that prove my fix is effective or that my feature works
- [No] New and existing unit tests pass locally with my changes
- [-] My changes generate no new warnings
