### PR TITLE
null check on children to not write aria-expanded for screen readers …

### DIFF
--- a/src/tree-node/index.js
+++ b/src/tree-node/index.js
@@ -81,8 +81,13 @@ class TreeNode extends PureComponent {
     attributes['aria-selected'] = checked
     if (mode !== 'simpleSelect') {
       attributes['aria-checked'] = partial ? 'mixed' : checked
-      attributes['aria-level'] = (_depth || 0) + 1
-      attributes['aria-expanded'] = _children && (expanded ? 'true' : 'false')
+      attributes['aria-level'] =
+        (_depth || 0) +
+        1(
+          _children !== undefined && _children.length > 0
+            ? (attributes['aria-expanded'] = _children && (expanded ? 'true' : 'false'))
+            : null
+        )
     }
     return attributes
   }


### PR DESCRIPTION
…if no children beneath parent exists

## What does it do?

"aria-expanded" was set to true or false in every condition - this rendered some issues with some screen readers whom read that the last section of the dropdown tree was mistaken for being closed. Even though it was the last node with no current children beneath its parent. This fix is ought to check that and not write aria-expanded attribute at all.

## Fixes # (issue)

Please mention in the format "Fixes #issueNumber" or "Closes #issueNumber".
This is important for semantic-release to correctly generate release tags and update issues.

## Type of change

Please delete options that are not relevant.

- [yes] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [no] I have performed a self-review of my own code
- [yes] I have commented my code, particularly in hard-to-understand areas
- [no] Updated documentation (if applicable)
- [no] Added tests that prove my fix is effective or that my feature works
- [no] New and existing unit tests pass locally with my changes
- [no] My changes generate no new warnings
