### PR TITLE
fix: Added missing prop 'inlineSearchPlaceholder' in 'TextProps' interface

### DIFF
--- a/types/react-dropdown-tree-select.d.ts
+++ b/types/react-dropdown-tree-select.d.ts
@@ -154,6 +154,8 @@ declare module 'react-dropdown-tree-select' {
   export interface TextProps {
     /** The text to display as placeholder on the search box. Defaults to Choose... */
     placeholder?: string
+    /** The text to display as placeholder on the inline search box. Only applicable with the `inlineSearchInput` setting. Defaults to `Search...` */
+    inlineSearchPlaceholder?: string
     /** The text to display when the search does not find results in the content list. Defaults to No matches found */
     noMatches?: string
     /** Adds `aria-labelledby` to search input when input starts with `#`, adds `aria-label` to search input when label has value (not containing '#') */


### PR DESCRIPTION
## What does it do?

Adds a missing prop in TextProps interface inside 'react-dropdown-tree-select.d.ts' according to the docs.

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] Updated documentation (if applicable)
- [    ] Added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] My changes generate no new warnings
