### PR TITLE
fix: Issue with searchPredicate function second argument(searchTerm)

### DIFF
--- a/src/tree-manager/index.js
+++ b/src/tree-manager/index.js
@@ -89,7 +89,7 @@ class TreeManager {
   }
 
   filterTree(searchTerm, keepTreeOnSearch, keepChildrenOnSearch) {
-    const matches = this.getMatches(searchTerm.toLowerCase())
+    const matches = this.getMatches(searchTerm)
 
     const matchTree = new Map()
 
@@ -289,7 +289,7 @@ class TreeManager {
   }
 
   _getAddOnMatch(matches, searchTerm) {
-    let isMatch = (node, term) => node.label.toLowerCase().indexOf(term) >= 0
+    let isMatch = (node, term) => node.label.toLowerCase().indexOf(term.toLowerCase()) >= 0
     if (typeof this.searchPredicate === 'function') {
       isMatch = this.searchPredicate
     }


### PR DESCRIPTION
## What does it do?

An issue with searchPredicate function second argument(searchTerm). Always received lowercase of search string. Needed the actual search string that is typed by a user.
Please check the issue on given eg:- [react-dropdown-tree-select-searchpredicate-issue](https://codesandbox.io/s/react-dropdown-tree-select-searchpredicate-issue-2hwh4
) 

## Fixes # (issue)

Updated position of converting searchTerm to lowercase.

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x  ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ ] Updated documentation (if applicable)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes generate no new warnings
