### PR TITLE
fix(compilation): Fixing the searchModeOn compilation problem

### DIFF
--- a/src/tree/index.js
+++ b/src/tree/index.js
@@ -5,15 +5,6 @@ import React, { Component } from 'react'
 import TreeNode from '../tree-node'
 import { findIndex } from '../utils'
 
-const shouldRenderNode = (node, searchModeOn, data) => {
-  if (searchModeOn || node.expanded) return true
-
-  const parent = node._parent && data.get(node._parent)
-  // if it has a parent, then check parent's state.
-  // otherwise root nodes are always rendered
-  return !parent || parent.expanded
-}
-
 class Tree extends Component {
   static propTypes = {
     data: PropTypes.object,
@@ -68,6 +59,17 @@ class Tree extends Component {
     }
   }
 
+  shouldRenderNode = (node, props) => {
+    const { data, searchModeOn } = props
+    const { expanded, _parent } = node
+    if (searchModeOn || expanded) return true
+
+    const parent = _parent && data.get(_parent)
+    // if it has a parent, then check parent's state.
+    // otherwise root nodes are always rendered
+    return !parent || parent.expanded
+  }
+
   getNodes = props => {
     const {
       data,
@@ -86,7 +88,7 @@ class Tree extends Component {
     } = props
     const items = []
     data.forEach(node => {
-      if (shouldRenderNode(node, searchModeOn, data)) {
+      if (this.shouldRenderNode(node, props)) {
         items.push(
           <TreeNode
             keepTreeOnSearch={keepTreeOnSearch}


### PR DESCRIPTION
## What does it do?

See issue #472 and discussion #479 for details and context. 

Only moved the "shouldRenderNode" method within the Tree component and changed its argument a bit to solve a compilation problem. I actually didn't get why that method was outside of the component... any reasons for that? 
I put it in the component because I thought this might solve the compilation problem I faced (along with the argument change). 

I needed this fix to properly compile this lib with react-scripts. I don't know why the bug I found actually happens, if it is something in the original code or the way react-scripts minify that lib dist files... but the fix I did actually solve my problem so... 

I didn't actually add any new unit tests... I'm not even sure how I could do a proper test for that bug as it only happens at compilation time within an app that actually uses that lib...

Please, let me know if I could improve my PR in any way. 
Thanks!

## Fixes # (issue)

Fixes #472 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
