### PR TITLE
fix(install): Adding react 17 to peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Visit [unpkg.com](https://unpkg.com/#/) to see other options.
 
 ### Peer Dependencies
 
-In order to avoid version conflicts in your project, you must specify and install [react](https://www.npmjs.com/package/react), [react-dom](https://www.npmjs.com/package/react-dom) as [peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/). Note that NPM doesn't install peer dependencies automatically. Instead it will show you a warning message with instructions on how to install them.
+In order to avoid version conflicts in your project, you must specify and install [react](https://www.npmjs.com/package/react), [react-dom](https://www.npmjs.com/package/react-dom) as [peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/). Note that NPM(version 4-6) doesn't install peer dependencies automatically. Instead it will show you a warning message with instructions on how to install them. If using Npm 7.X.X version, peer dependencies will be installed automatically.
 
 If you're using the UMD builds, you'd also need to install the peer dependencies in your application:
 

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "why-did-you-update": "^0.1.1"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.0.0 || ^17"
   },
   "ava": {
     "files": [


### PR DESCRIPTION
With NPM 7 peer dependencies are automatically installed unlike previous versions. Since React 17
was not defined as a peer dependency hence the install of package failed on projects using Npm7 + React
17.

React 17 support #486

## What does it do?
This fixes the install error that occurred when working with NPM 7 and React 17 by adding react 17 to peer dependencies.
Before 
![image](https://user-images.githubusercontent.com/80548347/117877858-b3ef1600-b26a-11eb-88c6-f548413509f9.png)
After
![image](https://user-images.githubusercontent.com/80548347/117877876-ba7d8d80-b26a-11eb-8fa0-91b01efb3641.png)


## Fixes # (issue)
Fixes #486 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] Updated documentation (if applicable)
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
