### PR TITLE
fix: Adds defensive code to keyboard navigation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -263,7 +263,7 @@ class DropdownTreeSelect extends Component {
         })
       }
     } else if (showDropdown && ['Escape', 'Tab'].indexOf(e.key) > -1) {
-      if (mode === 'simpleSelect' && tree.has(currentFocus)) {
+      if (mode === 'simpleSelect' && tree && tree.has(currentFocus)) {
         this.onCheckboxChange(currentFocus, true)
       } else {
         // Triggers close

--- a/src/tree-manager/nodeVisitor.js
+++ b/src/tree-manager/nodeVisitor.js
@@ -11,15 +11,16 @@ const getNodesMatching = (tree, nodePredicate) => {
   const nodes = []
   const visited = {}
 
-  tree.forEach((node, key) => {
-    if (visited[key]) return
+  tree &&
+    tree.forEach((node, key) => {
+      if (visited[key]) return
 
-    if (nodePredicate(node, key, visited)) {
-      nodes.push(node)
-    }
+      if (nodePredicate(node, key, visited)) {
+        nodes.push(node)
+      }
 
-    visited[key] = true
-  })
+      visited[key] = true
+    })
 
   return nodes
 }

--- a/src/tree-manager/tests/nodeVisitor.test.js
+++ b/src/tree-manager/tests/nodeVisitor.test.js
@@ -1,0 +1,7 @@
+import test from 'ava'
+import nodeVisitor from '../nodeVisitor'
+
+test('should return empty array if no tree is provided', t => {
+  const nodes = nodeVisitor.getNodesMatching(undefined)
+  t.true(nodes.length === 0)
+})


### PR DESCRIPTION
## Fixes # (issue)

Adds defensive code that was causing issues with getNodesMatching not having a tree passed in the arguments. Errors were thrown when calling 'forEach' on the undefined tree. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Updated documentation (if applicable)
- [x] Added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
