### PR TITLE
feat: Do not incur cost of filtering tree if search mode is off

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -148,18 +148,21 @@ class DropdownTreeSelect extends Component {
   }
 
   onInputChange = value => {
-    const { allNodesHidden, tree } = this.treeManager.filterTree(
-      value,
-      this.props.keepTreeOnSearch,
-      this.props.keepChildrenOnSearch
-    )
     const searchModeOn = value.length > 0
-
-    this.setState({
-      tree,
-      searchModeOn,
-      allNodesHidden,
-    })
+    if (!searchModeOn) {
+      this.setState(this.resetSearchState())
+    } else {
+      const { allNodesHidden, tree } = this.treeManager.filterTree(
+        value,
+        this.props.keepTreeOnSearch,
+        this.props.keepChildrenOnSearch
+      )
+      this.setState({
+        tree,
+        searchModeOn,
+        allNodesHidden,
+      })
+    }
   }
 
   onTagRemove = (id, isKeyboardEvent) => {


### PR DESCRIPTION
## What does it do?

When you have tens of thousands of items in a search tree, and you type search input, the cost can be extremely high when you have zero or one characters, especially when you are using a custom search predicate. There is no need to incur the cost of filtering the tree if the text input is zero length. Instead, just reset the search state.

I'll note here that the example in the demo that is supposed to test [a large-scale scenario](https://dowjones.github.io/react-dropdown-tree-select/#/story/large-tree) doesn't appear to be all that taxing because the number of nested nodes is very low. You need a lot of nested nodes to encounter performance issues. In my testing, I have almost 100k nodes at up to 10 levels of nesting. I also have `keepTreeOnSearch` on which probably exacerbates the issue.

This is the first change I would like to do. In a future PR, my intention would be to set the threshold (search term length) at which the search activates. When your search term is "a" you can trigger rendering of thousands of nodes potentially. So this parameter I am envisioning would basically prevent search mode until X characters...with some kind of visual indicator.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] I have performed a self-review of my own code
- [X] have commented my code, particularly in hard-to-understand areas
- [X] Updated documentation (if applicable)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] My changes generate no new warnings
