### PR TITLE
feat: Minimum react 18 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "prettier-stylelint": "^0.4.2",
     "prop-types": "^15.6.0",
     "raw-loader": "^0.5.1",
-    "react": "^16.0.0",
+    "react": "^16.3.0",
     "react-dom": "^16.0.0",
     "react-story": "^0.0.10",
     "rimraf": "^2.6.1",
@@ -116,7 +116,7 @@
     "why-did-you-update": "^0.1.1"
   },
   "peerDependencies": {
-    "react": "^16.0.0 || ^17"
+    "react": "^16.3.0 || ^17 || ^18"
   },
   "ava": {
     "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ class DropdownTreeSelect extends Component {
     }
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.initNewProps(this.props)
   }
 
@@ -114,7 +114,7 @@ class DropdownTreeSelect extends Component {
     document.removeEventListener('click', this.handleOutsideClick, false)
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.initNewProps(nextProps)
   }
 

--- a/src/tree/index.js
+++ b/src/tree/index.js
@@ -38,7 +38,7 @@ class Tree extends Component {
     }
   }
 
-  componentWillReceiveProps = nextProps => {
+  UNSAFE_componentWillReceiveProps = nextProps => {
     const { activeDescendant } = nextProps
     const hasSameActiveDescendant = activeDescendant === this.props.activeDescendant
     this.computeInstanceProps(nextProps, !hasSameActiveDescendant)

--- a/yarn.lock
+++ b/yarn.lock
@@ -9850,7 +9850,7 @@ react-test-renderer@^16.0.0-0:
     react-is "^16.8.6"
     scheduler "^0.13.6"
 
-react@^16.0.0:
+react@^16.3.0:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
   dependencies:


### PR DESCRIPTION
## What does it do?

Adds support for React 18, which ends support for certain lifecycle methods not prefixed by unsafe_.

See: https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html

For additional context

Fixes #560


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] Updated documentation (if applicable)
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
