### PR TITLE
fix(bug): Nodes expanded state are not updated when search #662

### DIFF
--- a/src/tree-node/index.js
+++ b/src/tree-node/index.js
@@ -73,7 +73,18 @@ class TreeNode extends PureComponent {
   }
 
   getAriaAttributes = () => {
-    const { _children, _depth, checked, disabled, expanded, readOnly, mode, partial } = this.props
+    const {
+      _children,
+      _depth,
+      checked,
+      disabled,
+      expanded,
+      keepTreeOnSearch,
+      mode,
+      partial,
+      readOnly,
+      searchModeOn,
+    } = this.props
     const attributes = {}
 
     attributes.role = mode === 'simpleSelect' ? 'option' : 'treeitem'
@@ -82,7 +93,8 @@ class TreeNode extends PureComponent {
     if (mode !== 'simpleSelect') {
       attributes['aria-checked'] = partial ? 'mixed' : checked
       attributes['aria-level'] = (_depth || 0) + 1
-      attributes['aria-expanded'] = _children && (expanded ? 'true' : 'false')
+      attributes['aria-expanded'] =
+        _children && (searchModeOn && keepTreeOnSearch ? 'true' : expanded ? 'true' : 'false')
     }
     return attributes
   }


### PR DESCRIPTION
## What does it do?

when we type something into the input field, the tree correctly displays results as a tree if keepTreeOnSearch is set to true.
but, the problem is that `aria-expanded` of node is `false`. So, Fixed that issue, whenever we found that `searchModeOn` and `keepTreeOnSearch` props are true at that time it sets `aria-expanded` to `true`

## Fixes #662 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] Updated documentation (if applicable)
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
